### PR TITLE
Enforced text-align:left in editor window

### DIFF
--- a/styles.less
+++ b/styles.less
@@ -43,6 +43,7 @@ form#dw__editform {
         border: 1px solid #ccc;
         border-radius: 2px;
         word-wrap: normal;
+        text-align: left;
     }
 
     .CodeMirror pre {


### PR DESCRIPTION
Chrome browsers "inherited" text-align: justify from Dokuwiki page,
which looked terrible with monospace font.