### PR TITLE
Add possibility to configure default usage of native editor via dokuwiki

### DIFF
--- a/action.php
+++ b/action.php
@@ -41,6 +41,7 @@ class action_plugin_codemirror extends DokuWiki_Action_Plugin {
             'iconURL' => "$base_url/settings.png",
             'languages' => $geshi->get_supported_languages(),
             'mathjax' => !plugin_isdisabled('mathjax'),
+            'nativeeditor' => $this->getConf('nativeeditor'),
             'schemes' => array_values(getSchemes()),
             'smileys' => array_keys(getSmileys()),
             'version' => $version,

--- a/conf/default.php
+++ b/conf/default.php
@@ -1,0 +1,3 @@
+<?php
+
+$conf['nativeeditor'] = '0';

--- a/conf/metadata.php
+++ b/conf/metadata.php
@@ -1,0 +1,5 @@
+<?php
+
+require_once(DOKU_INC.'lib/plugins/codemirror/action.php');
+
+$meta['nativeeditor'] = array('onoff');

--- a/init.js
+++ b/init.js
@@ -112,6 +112,9 @@ jQuery(function() {
         },
     };
 
+    // Use plugin configuration
+    settings['nativeeditor'].default_ = JSINFO.plugin_codemirror.nativeeditor;
+
     initMode();
     initHooks();
     initSettingsMenu();

--- a/lang/de/settings.php
+++ b/lang/de/settings.php
@@ -1,0 +1,3 @@
+<?php
+
+$lang['nativeeditor'] = 'Nativen DokuWiki Editor als Standard verwenden';

--- a/lang/en/settings.php
+++ b/lang/en/settings.php
@@ -1,0 +1,3 @@
+<?php
+
+$lang['nativeeditor'] = 'Use Native DokuWiki editor as default';


### PR DESCRIPTION
configuration dialog

Sometimes codemirror editor should not be the new default editor. For this it should be possible to configure that native editor is the default editor for new users. Default value in configuration dialog is to use codemirror as default, so this did not change default functionality. After enabling native editor as default the native editor will be used if there's no configuration value in user cookie.