### PR TITLE
Fix button box wrapping

### DIFF
--- a/styles.less
+++ b/styles.less
@@ -77,6 +77,10 @@ form#dw__editform {
     z-index: 1000;
 }
 
+div.dokuwiki div#size__ctl {
+    width: auto;
+}
+
 .cm-settings-button {
     cursor: pointer;
     margin-left: 20px;


### PR DESCRIPTION
Normally the `#size__ctl` button box has its width set at 60px, so `.cm-settings-button` appears below the first three.
![image](https://cloud.githubusercontent.com/assets/3324775/17217866/e3e2b106-54b3-11e6-9bc1-c182250079c5.png)
This unsets the box width so they appear in a single line.