### PR TITLE
Add new configuration option 'usenativescroll'

### DIFF
--- a/action.php
+++ b/action.php
@@ -47,6 +47,7 @@ class action_plugin_codemirror extends DokuWiki_Action_Plugin {
             'schemes' => array_values(getSchemes()),
             'smileys' => array_keys(getSmileys()),
             'version' => $version,
+            'usenativescroll' => $this->getConf('usenativescroll'),
         );
 
         $event->data['link'][] = array(

--- a/conf/default.php
+++ b/conf/default.php
@@ -2,3 +2,4 @@
 
 $conf['nativeeditor'] = '0';
 $conf['codesyntax'] = '0';
+$conf['usenativescroll'] = '0';

--- a/conf/metadata.php
+++ b/conf/metadata.php
@@ -4,3 +4,4 @@ require_once(DOKU_INC.'lib/plugins/codemirror/action.php');
 
 $meta['nativeeditor'] = array('onoff');
 $meta['codesyntax'] = array('onoff');
+$meta['usenativescroll'] = array('onoff');

--- a/init.js
+++ b/init.js
@@ -399,7 +399,10 @@ jQuery(function() {
                 jQuery('#edbtn__save').click();
             },
         });
-        cm.setOption('scrollbarStyle', 'overlay');
+        cm.setOption(
+            'scrollbarStyle',
+            JSINFO.plugin_codemirror.usenativescroll == 1 ? 'native' : 'overlay'
+        );
         cm.setSize(null, textarea.css('height'));
         cm.getDoc().on('change', function() {
             var now = new Date();

--- a/lang/en/settings.php
+++ b/lang/en/settings.php
@@ -2,3 +2,4 @@
 
 $lang['nativeeditor'] = 'Use native DokuWiki editor as default.';
 $lang['codesyntax'] = 'Use CodeMirror to highlight syntax of code blocks when viewing pages.';
+$lang['usenativescroll'] = 'Use native scrollbar style instead of overlay style default.';


### PR DESCRIPTION
I noticed in on [Feb 21, 2015](https://github.com/albertgasset/dokuwiki-plugin-codemirror/commit/3bc8fbc25af6fbbe133e579194462dfd43ec111c#diff-172cc6cf3ffdf57b151eaa939d6cb373) you added a CodeMirror setting

    cm.setOption('scrollbarStyle', 'overlay');

causing CodeMirror to use the 'overlay' scrollbar style instead of the default 'native'.

I much prefer to use the 'native' scrollbars. Can we have an option on the DokuWiki Configuration screen to provide this?

Attached is my patch to add it as an option and use the right CodeMirror option at run-time.