### PR TITLE
Adding 'autoheight' option and cleaning up code for usenativescroll

### DIFF
--- a/action.php
+++ b/action.php
@@ -48,6 +48,7 @@ class action_plugin_codemirror extends DokuWiki_Action_Plugin {
             'smileys' => array_keys(getSmileys()),
             'version' => $version,
             'usenativescroll' => $this->getConf('usenativescroll'),
+            'autoheight' => $this->getConf('autoheight'),
         );
 
         $event->data['link'][] = array(

--- a/conf/default.php
+++ b/conf/default.php
@@ -3,3 +3,4 @@
 $conf['nativeeditor'] = '0';
 $conf['codesyntax'] = '0';
 $conf['usenativescroll'] = '0';
+$conf['autoheight'] = '0';

--- a/conf/metadata.php
+++ b/conf/metadata.php
@@ -5,3 +5,4 @@ require_once(DOKU_INC.'lib/plugins/codemirror/action.php');
 $meta['nativeeditor'] = array('onoff');
 $meta['codesyntax'] = array('onoff');
 $meta['usenativescroll'] = array('onoff');
+$meta['autoheight'] = array('onoff');

--- a/init.js
+++ b/init.js
@@ -752,7 +752,7 @@ jQuery(function() {
         if(!setting.noCookie) {
             DokuCookie.setValue('cm-' + name, value);
         }
-        settings.callback(value);
+        setting.callback(value);
     }
 
     function requireKeyMap(name, callback) {

--- a/init.js
+++ b/init.js
@@ -329,6 +329,7 @@ jQuery(function() {
         },
         autoheight: {
             default_: JSINFO.plugin_codemirror.autoheight.toString(),
+            noCookie: true,
             callback: function(value) {
                 var sel = 'form#dw__editform .CodeMirror, #dokuwiki__content .CodeMirror';
                 if(value === '1') {
@@ -338,13 +339,15 @@ jQuery(function() {
                         '#size__ctl img[src$="/larger.gif"], ' +
                         '#size__ctl img[src$="/smaller.gif"]'
                     ).hide();
-                } else {
-                    jQuery(sel).removeAttr('style');
+                    if(cm) {
+                        cm.setOption('viewportMargin', Infinity);
+                    }
                 }
             }
         },
         usenativescroll: {
             default_: JSINFO.plugin_codemirror.usenativescroll.toString(),
+            noCookie: true,
             callback: function() {
                 // Do nothing; this is handled in initCodeMirror()
             }
@@ -603,8 +606,6 @@ jQuery(function() {
             'keymap',
             'closebrackets',
             'linenumbers',
-            'autoheight',
-            'usenativescroll',
             'activeline',
             'matchbrackets',
             'syntax',
@@ -721,8 +722,11 @@ jQuery(function() {
     }
 
     function getSetting(name) {
-        var value = DokuCookie.getValue('cm-' + name);
+        var value;
         var setting = settings[name];
+        if(!setting.noCookie) {
+            value = DokuCookie.getValue('cm-' + name);
+        }
 
         if (setting.choices) {
             // Choice setting
@@ -736,13 +740,17 @@ jQuery(function() {
             }
         }
 
-        DokuCookie.setValue('cm-' + name, value);
+        if(!setting.noCookie) {
+            DokuCookie.setValue('cm-' + name, value);
+        }
 
         return value;
     }
 
     function setSetting(name, value) {
-        DokuCookie.setValue('cm-' + name, value);
+        if(!settings[name].noCookie) {
+            DokuCookie.setValue('cm-' + name, value);
+        }
         settings[name].callback(value);
     }
 

--- a/init.js
+++ b/init.js
@@ -349,7 +349,10 @@ jQuery(function() {
             default_: JSINFO.plugin_codemirror.usenativescroll.toString(),
             noCookie: true,
             callback: function() {
-                // Do nothing; this is handled in initCodeMirror()
+                cm.setOption(
+                    'scrollbarStyle',
+                    getSetting('usenativescroll') ==='1' ? 'native' : 'overlay'
+                );
             }
         },
     };
@@ -440,10 +443,6 @@ jQuery(function() {
                 jQuery('#edbtn__save').click();
             },
         });
-        cm.setOption(
-            'scrollbarStyle',
-            getSetting('usenativescroll') ==='1' ? 'native' : 'overlay'
-        );
         cm.setSize(null, textarea.css('height'));
         cm.getDoc().on('change', function() {
             var now = new Date();

--- a/init.js
+++ b/init.js
@@ -331,8 +331,7 @@ jQuery(function() {
             default_: JSINFO.plugin_codemirror.autoheight.toString(),
             noCookie: true,
             callback: function(value) {
-                var sel = 'form#dw__editform .CodeMirror, ' +
-                    '#dokuwiki__content .CodeMirror';
+                var sel = 'form#dw__editform .CodeMirror';
                 if(value === '1') {
                     jQuery(sel).css({ height: 'auto' });
                     // Hide editor resize buttons

--- a/init.js
+++ b/init.js
@@ -401,12 +401,10 @@ jQuery(function() {
         jQuery('#codemirror__autoheight_style').remove();
         // Re-show larger/smaller buttons that were
         // hidden upon initialization.
-        jQuery('#size__ctl img').each(function() {
-            var img = jQuery(this);
-            if(img.attr('src').match(/\/(larger|smaller)\.gif$/)) {
-                img.show();
-            }
-        });
+        jQuery(
+            '#size__ctl img[src$="/larger.gif"], ' +
+            '#size__ctl img[src$="/smaller.gif"]'
+        ).show();
         textarea.focus();
     }
 
@@ -446,12 +444,10 @@ jQuery(function() {
             }
             cm.setOption('viewportMargin', Infinity);
             /* Hide editor resize buttons */
-            jQuery('#size__ctl img').each(function() {
-                var img = jQuery(this);
-                if(img.attr('src').match(/\/(larger|smaller)\.gif$/)) {
-                    img.hide();
-                }
-            });
+            jQuery(
+                '#size__ctl img[src$="/larger.gif"], ' +
+                '#size__ctl img[src$="/smaller.gif"]'
+            ).hide();
         } else {
             cm.setSize(null, textarea.css('height'));
         }

--- a/init.js
+++ b/init.js
@@ -748,10 +748,11 @@ jQuery(function() {
     }
 
     function setSetting(name, value) {
-        if(!settings[name].noCookie) {
+        var setting = settings[name];
+        if(!setting.noCookie) {
             DokuCookie.setValue('cm-' + name, value);
         }
-        settings[name].callback(value);
+        settings.callback(value);
     }
 
     function requireKeyMap(name, callback) {

--- a/init.js
+++ b/init.js
@@ -331,7 +331,8 @@ jQuery(function() {
             default_: JSINFO.plugin_codemirror.autoheight.toString(),
             noCookie: true,
             callback: function(value) {
-                var sel = 'form#dw__editform .CodeMirror, #dokuwiki__content .CodeMirror';
+                var sel = 'form#dw__editform .CodeMirror, ' +
+                    '#dokuwiki__content .CodeMirror';
                 if(value === '1') {
                     jQuery(sel).css({ height: 'auto' });
                     // Hide editor resize buttons

--- a/lang/en/lang.php
+++ b/lang/en/lang.php
@@ -9,3 +9,5 @@ $lang['js']['setting_matchbrackets'] = 'Highlight matching brackets';
 $lang['js']['setting_nativeeditor'] = 'Native DokuWiki editor';
 $lang['js']['setting_syntax'] = 'Highlight syntax';
 $lang['js']['setting_theme'] = 'Color theme';
+$lang['js']['setting_usenativescroll'] = 'Use native scrollbar';
+$lang['js']['setting_autoheight'] = 'Auto height';

--- a/lang/en/lang.php
+++ b/lang/en/lang.php
@@ -10,5 +10,3 @@ $lang['js']['setting_nativeeditor'] = 'Native DokuWiki editor';
 $lang['js']['setting_syntax'] = 'Highlight syntax';
 $lang['js']['setting_theme'] = 'Color theme';
 $lang['js']['setting_showinvisibles'] = 'Show Whitespace';
-$lang['js']['setting_usenativescroll'] = 'Use native scrollbar';
-$lang['js']['setting_autoheight'] = 'Auto height';

--- a/lang/en/settings.php
+++ b/lang/en/settings.php
@@ -3,3 +3,4 @@
 $lang['nativeeditor'] = 'Use native DokuWiki editor as default.';
 $lang['codesyntax'] = 'Use CodeMirror to highlight syntax of code blocks when viewing pages.';
 $lang['usenativescroll'] = 'Use native scrollbar style instead of overlay style default.';
+$lang['autoheight'] = 'Automatic height.';


### PR DESCRIPTION
My 'usenativescroll' option patch from the other day was a little rough and I've fixed that.

I'm also adding a new "autoheight" option that I need: When autoheight is turned on and CodeMirror editor is active, the "larger / smaller" buttons are hidden, and the CodeMirror work area is sized to fit the height of its content.

Sorry this got jumbled into one commit; I ended up working on both problems at the same time and couldn't easily separate the work.